### PR TITLE
Enhance event title display and update default term ID to Fall'26

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,7 @@ import { sanitizeDetailUrl } from '../shared/detailUrl.js';
 // Update these defaults each scheduling cycle.
 const DEFAULT_SELECTION = {
   campusId: '1',
-  termId: '202601',
+  termId: '202603',
   subjectId: 'CSCI',
 };
 
@@ -1720,7 +1720,7 @@ function App() {
                               width: `${event.widthPct}%`,
                               backgroundColor: event.color,
                             }}
-                            title={`${event.courseNumber} | ${event.title} | ${event.startLabel} - ${event.endLabel}${event.campusLabel ? ` | ${event.campusLabel}` : ''}`}
+                            title={`${event.courseNumber} | ${event.title} | ${event.startLabel} - ${event.endLabel}${event.campusLabel ? ` | ${event.campusLabel}` : ''}${event.instructor ? ` | ${event.instructor}` : ''}`}
                             role="button"
                             tabIndex={0}
                             onClick={(mouseEvent) => openCourseDetails(event.courseId, mouseEvent.currentTarget)}
@@ -1735,6 +1735,9 @@ function App() {
                             <p className="event-title">{event.title}</p>
                             {event.campusLabel ? (
                               <p className="event-campus">{event.campusLabel}</p>
+                            ) : null}
+                            {event.instructor ? (
+                              <p className="event-instructor">{event.instructor}</p>
                             ) : null}
                             <p>{event.startLabel}</p>
                             <p>{event.endLabel}</p>

--- a/src/styles.css
+++ b/src/styles.css
@@ -725,7 +725,8 @@ button:disabled {
   overflow: hidden;
 }
 
-.event-campus {
+.event-campus,
+.event-instructor {
   font-size: 0.64rem;
   opacity: 0.9;
   margin-bottom: 0.12rem;


### PR DESCRIPTION
This pull request updates the course scheduling UI to display instructor information for each event and updates the default term selection. The most important changes are grouped below:

UI improvements:

* The event tooltip (`title` attribute) now includes the instructor's name if available, providing more context when hovering over events.
* The event display now shows the instructor's name below the campus label if present, making instructor information visible in the event details.
* Updated styling so that instructor information matches the appearance of the campus label in the event display.

Default values update:

* Changed the default `termId` in the `DEFAULT_SELECTION` object from `'202601'` to `'202603'`, ensuring the application defaults to the latest term Fall'26.